### PR TITLE
Fix 404 error and persist custom stamps

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ npm run preview
 
 ---
 
+## カスタムスタンプの追加
+
+`src/components/StampMenu.tsx` から追加したスタンプは `localStorage` に保存され、次回以降のファイル読み込み時にも利用できます。任意のスタンプを入力して `追加` ボタンを押してください。
+
+---
+
 ## 2. `public` ディレクトリ
 
 ### `public/manifest.webmanifest`

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>PDF Annotator</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,10 +2,15 @@ import { useState } from 'react';
 import DropZone from './components/DropZone';
 import Viewer from './components/Viewer';
 import { AnnotatorFile, PageData } from './types/models';
+import { usePersistedState } from './hooks/usePersistedState';
 
 export default function App() {
   const [fileBuf, setFileBuf] = useState<ArrayBuffer | null>(null);
   const [data, setData] = useState<AnnotatorFile | null>(null);
+  const [customStamps, setCustomStamps] = usePersistedState<string[]>(
+    'custom-stamps',
+    []
+  );
 
   return (
     <div className="app">
@@ -13,6 +18,11 @@ export default function App() {
 
       <DropZone
         onLoad={(d, originalBuf) => {
+          if (d.customStamps.length === 0) {
+            d.customStamps = customStamps;
+          } else {
+            setCustomStamps(d.customStamps);
+          }
           setData(d);
           setFileBuf(originalBuf);
         }}
@@ -22,7 +32,10 @@ export default function App() {
         <Viewer
           fileBuf={fileBuf!}
           data={data}
-          onDataChange={(upd) => setData({ ...upd })}
+          onDataChange={(upd) => {
+            setData({ ...upd });
+            setCustomStamps(upd.customStamps);
+          }}
         />
       )}
     </div>

--- a/src/hooks/usePersistedState.ts
+++ b/src/hooks/usePersistedState.ts
@@ -1,0 +1,14 @@
+import { useEffect, useState } from 'react';
+
+export function usePersistedState<T>(key: string, defaultValue: T): [T, (v: T) => void] {
+  const [state, setState] = useState<T>(() => {
+    const stored = localStorage.getItem(key);
+    return stored ? (JSON.parse(stored) as T) : defaultValue;
+  });
+
+  useEffect(() => {
+    localStorage.setItem(key, JSON.stringify(state));
+  }, [key, state]);
+
+  return [state, setState];
+}


### PR DESCRIPTION
## Summary
- add missing `index.html` so the dev server works
- persist custom stamp list in `localStorage`
- document how to add custom stamps

## Testing
- `npm run type-check` *(fails: Cannot find module 'react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6854e71c18988329a5e14572f51cc374